### PR TITLE
Actions: Fix report generation by switching to a separate report branch

### DIFF
--- a/.github/workflows/build-report.yml
+++ b/.github/workflows/build-report.yml
@@ -2,8 +2,8 @@ name: Build Report
 on:
   push:
     branches:
-      # Run only on pushes to master
-      - master
+      # Run only on pushes to trunk
+      - trunk
 
   schedule:
     # Run every day at 9am UTC.
@@ -40,6 +40,7 @@ jobs:
         author_name: github-actions
         author_email: 41898282+github-actions[bot]@users.noreply.github.com
         message: "[Automated] Update report"
+        branch: "report"
         add: "public"
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fixes #32 — `trunk` is a protected branch, so I've switched the branch that github uses for displaying the report at https://wordpress.github.io/css-audit/public/wp-admin to `report`.

This PR updates the build action to push to this new branch.

I also caught a place where `master` was still being used, so I switched that back to trunk.