### PR TITLE
➕ ADD: Github repo link in <header> of Twig template

### DIFF
--- a/src/formats/html/index.twig
+++ b/src/formats/html/index.twig
@@ -8,7 +8,9 @@
 </head>
 <body>
 	<header class="site__header">
-		<h1 id="top">{{title}}</h1>
+		<h1 id="top">{{title}}</h1>'
+
+		<a href="https://github.com/WordPress/css-audit">Github</a>
 
 		<nav class="nav">
 			<ul>


### PR DESCRIPTION
Addresses #38

Screenshots of resulting output (in macOS 11.3.1 / Chrome 90.0.4430.212)

![Screen Shot 2021-05-18 at 11 58 23 AM](https://user-images.githubusercontent.com/405912/118699615-bbb93800-b7df-11eb-9476-f4aaed44bbc4.png)
![Screen Shot 2021-05-18 at 11 58 32 AM](https://user-images.githubusercontent.com/405912/118699621-bc51ce80-b7df-11eb-9dce-b2c847f7e4c7.png)
