### PR TITLE
fix: Add .gitattributes, update workflow yml

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+public/* merge=ours

--- a/.github/workflows/merge-trunk-to-report.yml
+++ b/.github/workflows/merge-trunk-to-report.yml
@@ -4,7 +4,7 @@ on:
     branches:
       # Run on pushes to trunk
       - 'trunk'
-  workflow_dispatch
+  workflow_dispatch:
 jobs:
   merge-branch:
     runs-on: ubuntu-latest

--- a/.github/workflows/merge-trunk-to-report.yml
+++ b/.github/workflows/merge-trunk-to-report.yml
@@ -4,10 +4,15 @@ on:
     branches:
       # Run on pushes to trunk
       - 'trunk'
+  workflow_dispatch
 jobs:
   merge-branch:
     runs-on: ubuntu-latest
     steps:
+      # Set config to ignore conflicts in /public
+      # specified in .gitattributes
+      - run: git config merge.ours.driver true
+      # Checkout report and merge trunk into it
       - uses: actions/checkout@v2
       - name: Merge trunk -> report
         uses: devmasx/merge-branch@v1.3.1


### PR DESCRIPTION
Implementing the [merge conflict resolution strategy outlined here](https://gist.github.com/tmaybe/4c9d94712711229cd506) (which works locally!)

* Add `.gitattributes` file to specify merge strategy for `public/*`
* Update `merge-trunk-report.yml` to set `git config merge.ours.driver true`
* Add `workflow_dispatch:` key to `merge-trunk-report.yml` to allow manual testing 