### PR TITLE
fix: Update workflow name

### DIFF
--- a/.github/workflows/merge-trunk-to-report.yml
+++ b/.github/workflows/merge-trunk-to-report.yml
@@ -1,4 +1,4 @@
-name: Merge trunk -> report
+name: Merge trunk into report branch
 on:
   push:
     branches:


### PR DESCRIPTION
The workflow name wasn’t displaying correctly on the GitHub actions page,
possibly because it contained reserved characters. I’m hoping this name
update will fix the issue