### PR TITLE
Audits: Add a report to generate statistics on alpha values

### DIFF
--- a/css-audit.config.js
+++ b/css-audit.config.js
@@ -3,6 +3,7 @@ module.exports = {
 	filename: 'wp-admin',
 	audits: [
 		'colors',
+		'alphas',
 		'important',
 		'display-none',
 		'selectors',

--- a/src/__tests__/alphas.js
+++ b/src/__tests__/alphas.js
@@ -1,0 +1,101 @@
+const audit = require( '../audits/alphas' );
+
+function getResultValue( results, key ) {
+	const { value } = results.find( ( { id } ) => key === id );
+	return value;
+}
+
+describe( 'Audit: Alphas', () => {
+	it( 'should return no values when no transparent colors are used', () => {
+		const files = [
+			{
+				name: 'a.css',
+				content: `body { font-size: 1em; line-height: 1.6; color: red }`,
+			},
+		];
+		const { results } = audit( files );
+		expect( getResultValue( results, 'unique' ) ).toBe( 0 );
+	} );
+
+	it( 'should count the number of alpha values in a file', () => {
+		const files = [
+			{
+				name: 'a.css',
+				content: `body { color: rgba(0, 0, 0, 0.3); }`,
+			},
+		];
+		const { results } = audit( files );
+		expect( getResultValue( results, 'unique' ) ).toBe( 1 );
+	} );
+
+	it( 'should find values across rulesets', () => {
+		const files = [
+			{
+				name: 'a.css',
+				content: `h1 { color: rgba(52, 0, 182, 0.95); }
+				h2 { color: rgba(206, 234, 196, .95); }
+				h3 { color: rgba( 119, 255, 214, 0.125); }
+				h4 { color: rgba(201, 15, 59, .875); }
+				h4 { color: rgba(0, 0, 0, 1); }`,
+			},
+		];
+		const { results } = audit( files );
+		expect( getResultValue( results, 'unique' ) ).toBe( 4 );
+		expect( getResultValue( results, 'unique-colors' ) ).toBe( 5 );
+		expect( getResultValue( results, 'all-alphas' ) ).toEqual( [
+			0.125,
+			0.875,
+			0.95,
+			1,
+		] );
+		expect( getResultValue( results, 'all-colors' ) ).toEqual( [
+			'rgba(52, 0, 182, 0.95)',
+			'rgba(206, 234, 196, .95)',
+			'rgba( 119, 255, 214, 0.125)',
+			'rgba(201, 15, 59, .875)',
+			'rgba(0, 0, 0, 1)',
+		] );
+	} );
+
+	it( 'should find values in all color functions', () => {
+		const files = [
+			{
+				name: 'a.css',
+				content: `h1 { color: hsla(95, 55%, 46%, 0.9); }
+				h2 { color: hsl(290, 72%, 24%, .333); }
+				h3 { color: rgb(41, 194, 191, 1); }
+				h4 { color: hsl(198 92 20 / 0.5); }
+				h5 { color: rgb(13 1 26 / 0.05); }`,
+			},
+		];
+		const { results } = audit( files );
+		expect( getResultValue( results, 'unique' ) ).toBe( 5 );
+		expect( getResultValue( results, 'unique-colors' ) ).toBe( 5 );
+		expect( getResultValue( results, 'all-alphas' ) ).toEqual( [
+			0.05,
+			0.333,
+			0.5,
+			0.9,
+			1,
+		] );
+		expect( getResultValue( results, 'all-colors' ) ).toEqual( [
+			'hsla(95, 55%, 46%, 0.9)',
+			'hsl(290, 72%, 24%, .333)',
+			'rgb(41, 194, 191, 1)',
+			'hsl(198 92 20 / 0.5)',
+			'rgb(13 1 26 / 0.05)',
+		] );
+	} );
+
+	it( 'should count alphas in shorthand properties', () => {
+		const files = [
+			{
+				name: 'a.css',
+				content: `body { border: 3px solid rgba(0, 0, 0, 0.5); }`,
+			},
+		];
+		const { results } = audit( files );
+		const { value } = results.find( ( { id } ) => 'unique' === id );
+		expect( value ).toBe( 1 );
+	} );
+} );

--- a/src/__tests__/alphas.js
+++ b/src/__tests__/alphas.js
@@ -43,17 +43,29 @@ describe( 'Audit: Alphas', () => {
 		expect( getResultValue( results, 'unique' ) ).toBe( 4 );
 		expect( getResultValue( results, 'unique-colors' ) ).toBe( 5 );
 		expect( getResultValue( results, 'all-alphas' ) ).toEqual( [
-			0.125,
-			0.875,
-			0.95,
-			1,
+			{
+				count: 2,
+				name: 0.95,
+			},
+			{
+				count: 1,
+				name: 0.125,
+			},
+			{
+				count: 1,
+				name: 0.875,
+			},
+			{
+				count: 1,
+				name: 1,
+			},
 		] );
 		expect( getResultValue( results, 'all-colors' ) ).toEqual( [
-			'rgba(52, 0, 182, 0.95)',
-			'rgba(206, 234, 196, .95)',
 			'rgba( 119, 255, 214, 0.125)',
-			'rgba(201, 15, 59, .875)',
 			'rgba(0, 0, 0, 1)',
+			'rgba(201, 15, 59, .875)',
+			'rgba(206, 234, 196, .95)',
+			'rgba(52, 0, 182, 0.95)',
 		] );
 	} );
 
@@ -72,18 +84,33 @@ describe( 'Audit: Alphas', () => {
 		expect( getResultValue( results, 'unique' ) ).toBe( 5 );
 		expect( getResultValue( results, 'unique-colors' ) ).toBe( 5 );
 		expect( getResultValue( results, 'all-alphas' ) ).toEqual( [
-			0.05,
-			0.333,
-			0.5,
-			0.9,
-			1,
+			{
+				count: 1,
+				name: 0.9,
+			},
+			{
+				count: 1,
+				name: 0.333,
+			},
+			{
+				count: 1,
+				name: 1,
+			},
+			{
+				count: 1,
+				name: 0.5,
+			},
+			{
+				count: 1,
+				name: 0.05,
+			},
 		] );
 		expect( getResultValue( results, 'all-colors' ) ).toEqual( [
-			'hsla(95, 55%, 46%, 0.9)',
-			'hsl(290, 72%, 24%, .333)',
-			'rgb(41, 194, 191, 1)',
 			'hsl(198 92 20 / 0.5)',
+			'hsl(290, 72%, 24%, .333)',
+			'hsla(95, 55%, 46%, 0.9)',
 			'rgb(13 1 26 / 0.05)',
+			'rgb(41, 194, 191, 1)',
 		] );
 	} );
 

--- a/src/audits/alphas.js
+++ b/src/audits/alphas.js
@@ -1,0 +1,70 @@
+/**
+ * External dependencies
+ */
+const { parse } = require( 'postcss' );
+const { parse: parseValue } = require( 'postcss-values-parser' );
+
+/**
+ * Internal dependencies
+ */
+const getValuesCount = require( '../utils/get-values-count' );
+
+module.exports = function ( files = [] ) {
+	const alphas = [];
+	const colors = [];
+
+	files.forEach( ( { content, name } ) => {
+		const root = parse( content, { from: name } );
+		root.walkDecls( function ( { value } ) {
+			try {
+				const valueRoot = parseValue( value, {
+					ignoreUnknownWords: true,
+				} );
+
+				valueRoot.walkFuncs( ( node ) => {
+					if ( node.isColor && node.nodes.length ) {
+						const values = node.nodes
+							.filter( ( n ) => 'numeric' === n.type )
+							.map( ( n ) => Number( n.value ) );
+						if ( values.length === 4 ) {
+							alphas.push( values[ 3 ] );
+							colors.push( node.toString() );
+						}
+					}
+				} );
+			} catch ( error ) {}
+		} );
+	} );
+
+	const uniqAlphas = [ ...new Set( alphas ) ];
+	const alphasByCount = getValuesCount( alphas );
+	const uniqColors = [ ...new Set( colors ) ];
+
+	return {
+		audit: 'alphas',
+		name: 'Opacities',
+		template: 'alpha',
+		results: [
+			{
+				id: 'unique',
+				label: 'Number of unique alphas',
+				value: uniqAlphas.length,
+			},
+			{
+				id: 'unique-colors',
+				label: 'Number of colors with opacity',
+				value: uniqColors.length,
+			},
+			{
+				id: 'all-alphas',
+				label: 'List of all alphas',
+				value: alphasByCount,
+			},
+			{
+				id: 'all-colors',
+				label: 'List of all colors with opacity',
+				value: uniqColors.sort(),
+			},
+		],
+	};
+};

--- a/src/formats/html/_audit-alpha.twig
+++ b/src/formats/html/_audit-alpha.twig
@@ -1,0 +1,23 @@
+{% for item in data.results %}
+	{% if item.value is iterable %}
+		<h3>{{item.label}}</h3>
+		<ul>
+		{% for value in item.value %}
+
+			{% if value.name or value.name == '0' %}
+				<li class="chip is-transparent" style="--chip-bg-color:{{value.name}};">
+					<span class="count">{{value.count}}</span>
+					{{value.name}}
+				</li>
+			{% else %}
+				<li class="chip is-transparent" style="--chip-bg-color:{{value}};">
+					{{value}}
+				</li>
+			{% endif %}
+
+		{% endfor %}
+		</ul>
+	{% else %}
+		<h3>{{ item.label}}: {{ item.value }}</h3>
+	{% endif %}
+{% endfor %}

--- a/src/formats/html/style.css
+++ b/src/formats/html/style.css
@@ -243,16 +243,18 @@ code {
 /*
 	Audit: Colors
 */
-.audit--colors ul {
+.audit--colors ul,
+.audit--alpha ul {
 	display: flex;
 	flex-wrap: wrap;
 	font-family: monospace;
 	font-size: 1.2em;
 	list-style: none;
 	padding: 0;
- }
+}
 
-.audit--colors .chip {
+.audit--colors .chip,
+.audit--alpha .chip {
 	border: var(--chip-border);
 	height: 3em;
 	line-height: 3em;
@@ -265,11 +267,24 @@ code {
 	position: relative;
 }
 
+.audit--colors .chip.is-transparent:before,
+.audit--alpha .chip.is-transparent:before {
+	content: '';
+	position: absolute;
+	top: 0;
+	left: 0;
+	right: 0;
+	bottom: 0;
+	z-index: -1;
+	background: repeating-conic-gradient(#f0f0f1 0% 25%, transparent 0% 50%) 50% / 20px 20px
+}
+
 /*
  * Improve visibility of colour chip
  * text on low contrast backgrounds
  */
-.audit--colors .chip:hover {
+.audit--colors .chip:hover,
+.audit--alpha .chip:hover {
 	font-weight: bold;
 	text-shadow: 0 0 1px var(--chip-text-shadow),
 	  0 0 3px var(--chip-text-shadow),
@@ -277,7 +292,8 @@ code {
 	  0 0 7px var(--chip-text-shadow);
 }
 
-.audit--colors .count {
+.audit--colors .count,
+.audit--alpha .count {
 	left: -1em;
 	min-width: 3em;
 	padding: unset;

--- a/src/run.js
+++ b/src/run.js
@@ -27,6 +27,9 @@ const runAudits = ( cssFiles ) => {
 	if ( getArg( '--typography' ) ) {
 		audits.push( require( './audits/typography' )( cssFiles ) );
 	}
+	if ( getArg( '--alphas' ) ) {
+		audits.push( require( './audits/alphas' )( cssFiles ) );
+	}
 
 	const propertyValues = getArg( '--property-values' );
 	const isPropertyValuesArray =


### PR DESCRIPTION
This PR adds a new audit to get an idea of the various opacities used in wp-admin CSS. The generated values are:

- Number of unique alphas
- List of all alpha values
- Number of colors with opacity
- List of all colors with opacity

![Screen Shot 2021-10-21 at 13 56 39](https://user-images.githubusercontent.com/541093/138331648-63c3c2a0-c953-4ebb-8dd3-231b644c1b7a.png)
![Screen Shot 2021-10-21 at 13 56 44](https://user-images.githubusercontent.com/541093/138331650-933321ec-9331-4c67-a5a9-25d696f7bba3.png)
