### PR TITLE
Tools: Run the report-building workflow from trunk

### DIFF
--- a/.github/workflows/build-report.yml
+++ b/.github/workflows/build-report.yml
@@ -15,9 +15,7 @@ jobs:
     steps:
     - name: Checkout CSS Audit
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      with:
-        ref: report
-
+  
     - name: Checkout WordPress Core
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:


### PR DESCRIPTION
This will ensure the reports are generated using the latest files, then committed to the `report` branch with the actions-js/push step.