### PR TITLE
Enhancement: Include Timestamp and Version in JSON Report Output

### DIFF
--- a/src/formats/json.js
+++ b/src/formats/json.js
@@ -1,3 +1,5 @@
+const { version } = require('../../package.json');
+
 /**
  * Convert the report data to a JSON string.
  *
@@ -5,5 +7,11 @@
  * @return {string} reports as a JSON string.
  */
 module.exports = function ( reports ) {
-	return JSON.stringify( reports.map( ( data ) => data ) );
+	const output = {
+		generatedAt: new Date().toISOString(),
+		version,
+		reports: reports.map( ( data ) => data ),
+	};
+
+	return JSON.stringify( output, null, 2 );
 };


### PR DESCRIPTION
Fixes #91

This enhancement adds two new metadata fields to the JSON report output:

- **`generatedAt`** – An ISO 8601 timestamp indicating when the report was generated.
- **`version`** – The current tool version retrieved from `package.json`.

The original audit data is now nested under a top-level `reports` key, ensuring the metadata is clearly separated from the actual results.

### Example Output:
```json
{
  "generatedAt": "2025-07-22T17:04:53.794Z",
  "version": "1.0.0",
  "reports": [
    [
      {
        "rule": "color-contrast",
        "result": "fail"
      },
      {
        "rule": "font-size",
        "result": "pass"
      }
    ]
  ]
}
